### PR TITLE
M korniak/integrate autoencoder with transformer

### DIFF
--- a/generator/src/model/model.py
+++ b/generator/src/model/model.py
@@ -15,9 +15,9 @@ import src.transformations.transformations as transformations
 
 @dataclass
 class ModelArgs:
-    dim: int = 256  # Play to determine the best value
+    dim: int = 64  # Play to determine the best value
     n_layers: int = 32
-    n_heads: int = 32
+    n_heads: int = 8
     multiple_of: int = 256  # make SwiGLU hidden layer size multiple of large power of 2
     norm_eps: float = 1e-5
     rope_theta: float = 21000
@@ -413,7 +413,8 @@ class Decoder(nn.Module):
                     out_channels=out_channels,
                     kernel_size=args.kernel_sizes[i],
                     stride=self.scaling_factor,
-                    padding=args.paddings[i]
+                    padding=args.paddings[i],
+                    output_padding=1
                 )
             )
 

--- a/generator/src/model/model.py
+++ b/generator/src/model/model.py
@@ -411,10 +411,9 @@ class Decoder(nn.Module):
                 nn.ConvTranspose2d(
                     in_channels=in_channels,
                     out_channels=out_channels,
-                    kernel_size=args.kernel_sizes[i],
+                    kernel_size=args.kernel_sizes[i] + 1,
                     stride=self.scaling_factor,
                     padding=args.paddings[i],
-                    output_padding=1
                 )
             )
 

--- a/generator/src/transformations/transformations.py
+++ b/generator/src/transformations/transformations.py
@@ -69,7 +69,7 @@ def unnormalize_image(image: torch.Tensor) -> torch.Tensor:
     return image * std + mean
 
 
-def transform_gif_to_tensor(gif_path: str) -> torch.Tensor:
+def transform_gif_to_tensor(gif_path: str = "../../data/simulation.gif") -> torch.Tensor:
     """
     Transforms a .gif file to a normalized, cropped tensor.
 

--- a/generator/src/transformations/transformations.py
+++ b/generator/src/transformations/transformations.py
@@ -1,6 +1,9 @@
 import imageio
-import torch
 import numpy as np
+import torch
+import matplotlib.pyplot as plt
+
+from torchvision import transforms
 
 MEANS = [224.0111, 235.0948, 226.7944]
 STDS = [69.3141, 54.4987, 63.4723]
@@ -68,6 +71,23 @@ def unnormalize_image(image: torch.Tensor) -> torch.Tensor:
     std = torch.tensor(STDS).view(3, 1, 1)
     return image * std + mean
 
+def resize_image(image: torch.Tensor, size: int = 256) -> torch.Tensor:
+    """
+    Resizes batched image tensor to a square size.
+
+    Args:
+    - image (torch.Tensor): The image tensor to resize.
+    - size (int): The size to resize the image to.
+
+    Returns:
+    - torch.Tensor: The resized image tensor.
+    """
+    B, S = image.shape[:2]
+    image = image.view(B * S, *image.shape[2:])
+    resize_transform = transforms.Resize((size, size), antialias=False)
+    image = resize_transform(image)
+    return image.view(B, S, *image.shape[1:])
+
 
 def transform_gif_to_tensor(gif_path: str = "../../data/simulation.gif") -> torch.Tensor:
     """
@@ -81,8 +101,11 @@ def transform_gif_to_tensor(gif_path: str = "../../data/simulation.gif") -> torc
     """
     frames = load_gif(gif_path)
     frames = crop_to_field_of_view(frames)
+    frames = resize_image(frames)
     frames = normalize_image(frames)
     return frames
+
+
 
 
 


### PR DESCRIPTION
Tried to rewrite the Autoencoder implementation to the repo.
NOTE:
- the shape before encoder and after decoder work well for input sizes that are power of 2
- Example usage in model.py class 
- Separated Encoder and Decoder since there will be a transformer between them.